### PR TITLE
spawn each connection into a different tokio task

### DIFF
--- a/src/webtransport_server.rs
+++ b/src/webtransport_server.rs
@@ -150,7 +150,11 @@ async fn handle_connection(mut conn: Connection<h3_quinn::Connection, Bytes>) ->
                         info!("Established webtransport session");
                         // 4. Get datagrams, bidirectional streams, and unidirectional streams and wait for client requests here.
                         // h3_conn needs to handover the datagrams, bidirectional streams, and unidirectional streams to the webtransport session.
-                        handle_session(session).await?;
+                        tokio::spawn(async move {
+                            if let Err(err) = handle_session(session).await {
+                                error!("Failed to handle session: {err:?}");
+                            }
+                        });
                         return Ok(());
                     }
                     _ => {


### PR DESCRIPTION
prior to this change all connections were running on the same task which I am sure caused issues